### PR TITLE
Replaced 0 values of column series with null

### DIFF
--- a/FRONTEND/src/chartHooks/ColumnSeriesChart.tsx
+++ b/FRONTEND/src/chartHooks/ColumnSeriesChart.tsx
@@ -57,7 +57,7 @@ function ColumnSeriesChart(props: ITimeSeriesProps): JSX.Element {
         max: new Date(initialDate.end_date as string).getTime(),
         strictMinMaxSelection: true,
         maxDeviation: 0.1,
-        groupData:true,
+        groupData: true,
         baseInterval: {
           timeUnit: "day",
           count: 1,
@@ -235,7 +235,13 @@ function ColumnSeriesChart(props: ITimeSeriesProps): JSX.Element {
       const sbSeries = scrollbarRef.current.chart.series.getIndex(0);
 
       if (mainSeries && sbSeries) {
-        mainSeries.data.setAll(props.data);
+        // replacing 0 values with null for columnSeries
+        const processedData = props.data.map(({ date, value }) => ({
+          date,
+          value: value || null,
+        }));
+
+        mainSeries.data.setAll(processedData);
         sbSeries.data.setAll(props.data);
       }
 


### PR DESCRIPTION
Column series treats 0 as a value rather than absence of value. This hides relevant data points when singled out by grouping with the zero value. Replacing zero value with null (absence of value or no value) so that it does not groups unnecessarilly and shows up on the chart